### PR TITLE
Fix #5

### DIFF
--- a/backend/.babelrc
+++ b/backend/.babelrc
@@ -1,3 +1,6 @@
 {
-  "presets": ["@babel/preset-env"]
+  "presets": ["@babel/preset-env"],
+  "plugins": [
+    "babel-plugin-dev-expression"
+  ]
 }

--- a/backend/package.json
+++ b/backend/package.json
@@ -36,6 +36,7 @@
     "@babel/core": "^7.1.2",
     "@babel/node": "^7.0.0",
     "@babel/preset-env": "^7.1.0",
+    "babel-plugin-dev-expression": "^0.2.1",
     "nodemon": "^1.18.4"
   }
 }

--- a/frontend/.babelrc
+++ b/frontend/.babelrc
@@ -1,6 +1,7 @@
 {
   "presets": ["next/babel"],
   "plugins": [
+    "babel-plugin-dev-expression",
     [
       "styled-components",
       {

--- a/frontend/lib/init-apollo.js
+++ b/frontend/lib/init-apollo.js
@@ -5,7 +5,6 @@ import fetch from 'isomorphic-unfetch';
 let apolloClient = null;
 
 const isBrowser = process.browser;
-const isProduction = true;
 
 const devEndpoint = 'http://localhost:8080/graphql';
 const prodEndpoint = 'http://rfs-api.reactiveacademy.com/graphql';
@@ -17,7 +16,7 @@ if (!process.browser) {
 
 function create(initialState, { getToken }) {
   const httpLink = new HttpLink({
-    uri: isProduction ? prodEndpoint : devEndpoint,
+    uri: __DEV__ ? devEndpoint : prodEndpoint,
     credentials: 'include',
   });
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,6 +28,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
+    "babel-plugin-dev-expression": "^0.2.1",
     "babel-plugin-styled-components": "^1.8.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,13 +7,15 @@
     "backend"
   ],
   "scripts": {
-    "frontend:dev": "yarn workspace frontend dev",
-    "frontend:build": "yarn workspace frontend build",
+    "frontend": "yarn workspace frontend",
+    "frontend:dev": "NODE_ENV='development' yarn workspace frontend dev",
+    "frontend:build": "NODE_ENV='production' yarn workspace frontend build",
     "frontend:start": "yarn workspace frontend start",
     "frontend:deploy": "git subtree push --prefix frontend heroku-frontend master",
     "frontend:logs": "heroku logs --tail --app rfs-frontend",
-    "backend:dev": "yarn workspace backend dev",
-    "backend:build": "yarn workspace backend build",
+    "backend": "yarn workspace backend",
+    "backend:dev": "NODE_ENV='development' yarn workspace backend dev",
+    "backend:build": "NODE_ENV='production' yarn workspace backend build",
     "backend:start": "yarn workspace backend start",
     "backend:deploy": "git subtree push --prefix backend heroku-backend master",
     "backend:logs": "heroku logs --tail --app rfs-backend"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1205,6 +1205,11 @@ babel-loader@8.0.2:
     mkdirp "^0.5.1"
     util.promisify "^1.0.0"
 
+babel-plugin-dev-expression@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-dev-expression/-/babel-plugin-dev-expression-0.2.1.tgz#d4a7beefefbb50e3f2734990a82a2486cf9eb9ee"
+  integrity sha1-1Ke+7++7UOPyc0mQqCokhs+eue4=
+
 babel-plugin-react-require@3.0.0:
   version "3.0.0"
   resolved "http://registry.npmjs.org/babel-plugin-react-require/-/babel-plugin-react-require-3.0.0.tgz#2e4e7b4496b93a654a1c80042276de4e4eeb20e3"


### PR DESCRIPTION
Fixes #5.

1. Created workspace shortcuts via npm scripts.

```
# This:
yarn workspace frontend add -D whatever
# ... can now be done more easily like so:
yarn frontend add -D whatever
```

2. Added `NODE_ENV` declarations.

```
# So we can designate which environment we are working on.
# Also required for (3) of this list. :)
NODE_ENV='development'
NODE_ENV='production'
```

3. Added `babel-plugin-dev-expression`.

```js
// If NODE_ENV='development', __DEV__ will be true.
__DEV__
```

4. Used `__DEV__` in `init-apollo.js`.

Replaced the static `isProduction` with `__DEV__`.