### PR TITLE
Fixed scrolling aesthetic. Ignored .vscode folder.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.vscode

--- a/frontend/components/dashboard/communities.component.js
+++ b/frontend/components/dashboard/communities.component.js
@@ -9,7 +9,7 @@ import Community from './community.component';
 
 const Communities = styled.div`
   grid-area: communities;
-  overflow-y: scroll;
+  overflow-y: auto;
   border-right: 1px solid ${scheme.gray[4]};
 `;
 

--- a/frontend/components/dashboard/threads.component.js
+++ b/frontend/components/dashboard/threads.component.js
@@ -15,7 +15,7 @@ import ThreadList from './thread-list.component';
 
 const Threads = styled.div`
   grid-area: threads;
-  overflow-y: scroll;
+  overflow-y: auto;
   border-right: 1px solid ${scheme.gray[4]};
 `;
 


### PR DESCRIPTION
Scroll bars were present even when the content was not scrollable. I changed a wee bit of CSS to make them `auto`, so they only show up when scrolling is an option. :+1:

Also added `.vscode` to `.gitignore`, because... well, it is generally a thing we need to ignore, and VS Code tends to create it in the directories we work in. =/

Before: 
![screenshot from 2018-11-24 23-56-36](https://user-images.githubusercontent.com/19484365/48986379-c8121d80-f0d9-11e8-81f1-8b28aec01004.png)

After:
![screenshot from 2018-11-24 23-56-16](https://user-images.githubusercontent.com/19484365/48986393-014a8d80-f0da-11e8-950d-d45ead864442.png)
